### PR TITLE
Update zip_next to 0.11 and expose Zopfli feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ deflate = ["zip_next/deflate"]
 deflate64 = ["zip_next/deflate64"]
 deflate-miniz = ["zip_next/deflate-miniz"]
 deflate-zlib = ["zip_next/deflate-zlib"]
+deflate-zopfli = ["zip_next/deflate-zopfli"]
 unreserved = ["zip_next/unreserved"]
 bzip2 = ["zip_next/bzip2"]
 time = ["zip_next/time"]
@@ -23,7 +24,7 @@ default = ["aes-crypto", "bzip2", "deflate", "deflate64", "zstd"]
 
 [dependencies]
 log = "0.4"
-zip_next = { git = "https://github.com/anatawa12/zip-rs", branch = "deflate64-next" }
+zip_next = "0.11"
 encoding_rs = "0.8"
 thiserror = "1.0"
 


### PR DESCRIPTION
`deflate64` integration in `zip_next` was released yesterday in version 0.11.0, along with a number of bug fixes that prevent a panic on invalid ZIP files.